### PR TITLE
Update ReadMe to add step for system keyring.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The easiest way to run this demo is locally.
 
 A global agentic profile is available from anywhere on the internet.  The "did:web" variant DID documents are
 available via HTTPS which is used in the example below.  We use the "test.agenticprofile.ai" domain for
-hosting temporary profiles for teating.
+hosting temporary profiles for testing.
 
 
 1. Create an .env file to support "admin" features.  See example.env for more information.
@@ -66,13 +66,17 @@ hosting temporary profiles for teating.
 
     $ yarn dev
 
-3. Create a global demo agentic profile with public and private keys, and a local account (uid=2) on the server
+3. Set up the system keyring for the server (required for verification):
+
+    $ node scripts/setup-well-known-agent.js
+
+4. Create a global demo agentic profile with public and private keys, and a local account (uid=2) on the server
 
     $ node scripts/create-global-agentic-profile
 
     You can review the results in your ~/.agentic/iam/global-me directory...
 
-4. Use CURL to (try to) send a chat message:
+5. Use CURL to (try to) send a chat message:
 
     $ curl -X PUT http://localhost:3003/users/2/agent-chats
 
@@ -86,7 +90,7 @@ hosting temporary profiles for teating.
         }
     }
 
-5. Send a chat message.  This script automatically handles the challenge and generates an authorization token from the global agentic profile in step #3.
+6. Send a chat message.  This script automatically handles the challenge and generates an authorization token from the global agentic profile in step #4.
 
     $ node scripts/send-chat-message 
 


### PR DESCRIPTION
- Add required step to readme to run setup-well-known-agent.js to set system keyring.json file in local project directory before testing locally 

Was previously running into the following error:

isabellafarley@Isabellas-MBP-2 agentic-profile-express % node scripts/send-chat-message
Failed to send chat message Error: Failed to load /Users/isabellafarley/Coding/Tools/agentic_profile/agentic-profile-express/keyring.json - file not found
    at loadJson (file:///Users/isabellafarley/Coding/Tools/agentic_profile/agentic-profile-express/node_modules/@agentic-profile/express-common/dist/index.js:237:11)
    at async createProfileResolver (file:///Users/isabellafarley/Coding/Tools/agentic_profile/agentic-profile-express/scripts/util.js:24:21)
    at async file:///Users/isabellafarley/Coding/Tools/agentic_profile/agentic-profile-express/scripts/send-chat-message.js:31:58